### PR TITLE
feat(boxes): added route to show details of a specific box

### DIFF
--- a/src/lib/components/DataTable.svelte
+++ b/src/lib/components/DataTable.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import { page } from '$app/stores';
 	import { PUBLIC_PB_BASE_URL } from '$env/static/public';
 	import { editMode, selectedId } from '$lib/storeClient';
 	import { BreakPoints } from '$lib/types/breakpoints';
@@ -62,7 +63,7 @@
 </script>
 
 <svelte:window bind:innerWidth bind:innerHeight />
-<div class="relative overflow-x-auto shadow-md sm:rounded-lg">
+<div class="relative overflow-x-auto shadow-md sm:rounded-lg mt-4">
 	{#if $editMode === true}
 		<div class="pb-4">
 			{#if user?.role === UserRoles.INVENTARIST && !disableEdit}
@@ -157,7 +158,20 @@
 					{/if}
 					{#each dataFields as dataField}
 						{#if dataField.isExpanded}
-							<td> {dataRow['expand'][dataField.name][dataField.fieldName ?? '']} </td>
+							{#if dataField.detailsLink}
+								<td>
+									<a
+										class="underline underline-offset-4 decoration-dotted hover:cursor-pointer"
+										href="{typeof dataField.detailsLink === 'string'
+											? dataField.detailsLink
+											: $page.url.pathname}/{dataRow['expand'][dataField.name]['id']}"
+									>
+										{dataRow['expand'][dataField.name][dataField.fieldName ?? '']}
+									</a>
+								</td>
+							{:else}
+								<td> {dataRow['expand'][dataField.name][dataField.fieldName ?? '']} </td>
+							{/if}
 						{:else if dataField.isImage}
 							<td>
 								{#if dataRow[dataField.name]}
@@ -180,8 +194,19 @@
 									<span>Nicht vorhanden</span>
 								{/if}
 							</td>
+						{:else if dataField.detailsLink}
+							<td>
+								<a
+									class="underline underline-offset-4 decoration-dotted hover:cursor-pointer"
+									href="{typeof dataField.detailsLink === 'string'
+										? dataField.detailsLink
+										: $page.url.pathname}/{dataRow['id']}"
+								>
+									{dataRow[dataField.name]}
+								</a>
+							</td>
 						{:else}
-							<td>{dataRow[dataField.name]}</td>
+							<td> {dataRow[dataField.name]} </td>
 						{/if}
 					{/each}
 				</tr>

--- a/src/lib/server/pocketbase.ts
+++ b/src/lib/server/pocketbase.ts
@@ -18,11 +18,42 @@ const getGegenstaende = async (pb: PocketBase) => {
 	return data;
 };
 
+const getGegenstaendeForKiste = async (pb: PocketBase, id: string) => {
+	let data: Gegenstand[] = [];
+
+	try {
+		data = await pb.collection('gegenstaende').getFullList<Gegenstand>(200, {
+			sort: '-created',
+			filter: `kiste.id = "${id}"`,
+			expand: 'kiste'
+		});
+	} catch (error) {
+		console.error(error);
+	}
+
+	return data;
+};
+
 const getKisten = async (pb: PocketBase) => {
 	let data: Kiste[] = [];
 
 	try {
 		data = await pb.collection('kisten').getFullList<Kiste>(200, {
+			sort: '-created',
+			expand: 'projekt, lagerort'
+		});
+	} catch (error) {
+		console.error(error);
+	}
+
+	return data;
+};
+
+const getKistenById = async (pb: PocketBase, id: string) => {
+	let data: Kiste | undefined = undefined;
+
+	try {
+		data = await pb.collection('kisten').getFirstListItem<Kiste>(`id="${id}"`, {
 			sort: '-created',
 			expand: 'projekt, lagerort'
 		});
@@ -47,4 +78,4 @@ const getLagerorte = async (pb: PocketBase) => {
 	return data;
 };
 
-export { getGegenstaende, getKisten, getLagerorte };
+export { getGegenstaende, getGegenstaendeForKiste, getKisten, getKistenById, getLagerorte };

--- a/src/lib/server/pocketbase.ts
+++ b/src/lib/server/pocketbase.ts
@@ -25,7 +25,7 @@ const getGegenstaendeForKiste = async (pb: PocketBase, id: string) => {
 		data = await pb.collection('gegenstaende').getFullList<Gegenstand>(200, {
 			sort: '-created',
 			filter: `kiste.id = "${id}"`,
-			expand: 'kiste'
+			expand: 'kiste, kiste.lagerort'
 		});
 	} catch (error) {
 		console.error(error);

--- a/src/lib/server/storeServer.ts
+++ b/src/lib/server/storeServer.ts
@@ -1,6 +1,8 @@
+import type { Gegenstand } from '$lib/types/gegenstand';
 import type { Kiste } from '$lib/types/kiste';
 import type { Lagerort } from '$lib/types/lagerort';
 import { writable, type Writable } from 'svelte/store';
 
 export const lagerortStore: Writable<Lagerort[]> = writable([] as Lagerort[]);
 export const kistenStore: Writable<Kiste[]> = writable([] as Kiste[]);
+export const gegenstaendeStore: Writable<Gegenstand[]> = writable([] as Gegenstand[]);

--- a/src/lib/types/dataField.ts
+++ b/src/lib/types/dataField.ts
@@ -3,4 +3,5 @@ export interface DBField {
 	isExpanded?: boolean;
 	fieldName?: string;
 	isImage?: boolean;
+	detailsLink?: boolean | string;
 }

--- a/src/routes/gegenstand/+page.server.ts
+++ b/src/routes/gegenstand/+page.server.ts
@@ -20,6 +20,9 @@ export const load = (async ({
 	const kisten = await getKisten(locals.pb);
 	kistenStore.set(kisten);
 
+	gegenstaende.forEach((element) => {
+		console.warn(element.expand.kiste.id);
+	});
 	return {
 		gegenstaende: JSON.parse(JSON.stringify(gegenstaende)),
 		kisten: kisten.map((x: Kiste) => x.name)

--- a/src/routes/gegenstand/+page.server.ts
+++ b/src/routes/gegenstand/+page.server.ts
@@ -20,9 +20,6 @@ export const load = (async ({
 	const kisten = await getKisten(locals.pb);
 	kistenStore.set(kisten);
 
-	gegenstaende.forEach((element) => {
-		console.warn(element.expand.kiste.id);
-	});
 	return {
 		gegenstaende: JSON.parse(JSON.stringify(gegenstaende)),
 		kisten: kisten.map((x: Kiste) => x.name)

--- a/src/routes/gegenstand/+page.svelte
+++ b/src/routes/gegenstand/+page.svelte
@@ -46,7 +46,7 @@
 			{ name: 'name' },
 			{ name: 'anzahl' },
 			{ name: 'bild', isImage: true },
-			{ name: 'kiste', isExpanded: true, fieldName: 'name' }
+			{ name: 'kiste', isExpanded: true, fieldName: 'name', detailsLink: 'kiste' }
 		]}
 		tableHeaders={['Name', 'Anzahl', 'Bild', 'Kiste']}
 		user={data.user}

--- a/src/routes/kiste/+page.svelte
+++ b/src/routes/kiste/+page.svelte
@@ -41,7 +41,10 @@
 <div class="w-full h-full px-2">
 	<DataTable
 		data={data.kisten}
-		dataFields={[{ name: 'name' }, { name: 'lagerort', isExpanded: true, fieldName: 'name' }]}
+		dataFields={[
+			{ name: 'name', detailsLink: true },
+			{ name: 'lagerort', isExpanded: true, fieldName: 'name' }
+		]}
 		tableHeaders={['Name', 'Lagerort']}
 		user={data.user}
 		textButtonNeu="Kiste anlegen"

--- a/src/routes/kiste/[id]/+page.server.ts
+++ b/src/routes/kiste/[id]/+page.server.ts
@@ -1,0 +1,20 @@
+import { getGegenstaendeForKiste, getKistenById } from '$lib/server/pocketbase';
+import { gegenstaendeStore } from '$lib/server/storeServer';
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load = (async ({ locals, params }) => {
+	if (!locals.pb.authStore.isValid) {
+		throw redirect(303, '/login');
+	}
+
+	const gegenstaende = await getGegenstaendeForKiste(locals.pb, params.id);
+	gegenstaendeStore.set(gegenstaende);
+
+	const kiste = await getKistenById(locals.pb, params.id);
+
+	return {
+		gegenstaende: JSON.parse(JSON.stringify(gegenstaende)),
+		kiste: JSON.parse(JSON.stringify(kiste))
+	};
+}) satisfies PageServerLoad;

--- a/src/routes/kiste/[id]/+page.svelte
+++ b/src/routes/kiste/[id]/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import DataTable from '$lib/components/DataTable.svelte';
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+</script>
+
+<div class="w-full h-full px-2">
+	<h1 class="text-4xl font-bold">{data.kiste?.name}</h1>
+	<DataTable
+		data={data.gegenstaende}
+		dataFields={[
+			{ name: 'name' },
+			{ name: 'anzahl' },
+			{ name: 'bild', isImage: true },
+			{ name: 'kiste', isExpanded: true, fieldName: 'name' }
+		]}
+		tableHeaders={['Name', 'Anzahl', 'Bild', 'Kiste']}
+		user={data.user}
+		disableEdit={true}
+		csvName="{`gegenstaende-${data.kiste.name}`}.csv"
+	/>
+</div>

--- a/src/routes/kiste/[id]/+page.svelte
+++ b/src/routes/kiste/[id]/+page.svelte
@@ -14,13 +14,8 @@
 
 	<DataTable
 		data={data.gegenstaende}
-		dataFields={[
-			{ name: 'name' },
-			{ name: 'anzahl' },
-			{ name: 'bild', isImage: true },
-			{ name: 'kiste', isExpanded: true, fieldName: 'name' }
-		]}
-		tableHeaders={['Name', 'Anzahl', 'Bild', 'Kiste']}
+		dataFields={[{ name: 'name' }, { name: 'anzahl' }, { name: 'bild', isImage: true }]}
+		tableHeaders={['Name', 'Anzahl', 'Bild']}
 		user={data.user}
 		disableEdit={true}
 		csvName="{`gegenstaende-${data.kiste.name}`}.csv"

--- a/src/routes/kiste/[id]/+page.svelte
+++ b/src/routes/kiste/[id]/+page.svelte
@@ -6,7 +6,12 @@
 </script>
 
 <div class="w-full h-full px-2">
-	<h1 class="text-4xl font-bold">{data.kiste?.name}</h1>
+	<h1 class="text-4xl font-bold mb-4">{data.kiste?.name}</h1>
+	<label for="lagerort">
+		<span class="font-bold"> Lagerort: </span>
+	</label>
+	<span id="lagerort"> {data.kiste?.expand.lagerort.name} </span>
+
 	<DataTable
 		data={data.gegenstaende}
 		dataFields={[


### PR DESCRIPTION
- added route to show details of a specific box
- added an option to the DBField to indicate a field is a link
- if that option is set the field in the DataTable is displayed as a link for both expanded as well as 'standard' fields
- added a function to the pocketbase util class to get items (Gegenstände) for a specific box (Kiste)
- added a function to the pocketbase util class to get a specific box by id
- added a store for a gegenstaende list to make the store list complete (checks for a already existing/filled store will come later)
- set the name field in the boxes (Kisten) route to display as a detail link
- set the kisten field in the items (Gegenstaende) route to display as a detail link