### PR TITLE
feat(boxes): added detaillink to boxes (kisten) route

### DIFF
--- a/src/routes/kiste/+page.svelte
+++ b/src/routes/kiste/+page.svelte
@@ -43,7 +43,7 @@
 		data={data.kisten}
 		dataFields={[
 			{ name: 'name', detailsLink: true },
-			{ name: 'lagerort', isExpanded: true, fieldName: 'name' }
+			{ name: 'lagerort', isExpanded: true, fieldName: 'name', detailsLink: 'lagerort' }
 		]}
 		tableHeaders={['Name', 'Lagerort']}
 		user={data.user}


### PR DESCRIPTION
- the name of the storage location (Lagerort) is now a link to the detail route of said storage location