### PR TITLE
feat(boxes): added box select to item create dialog on box detail route

### DIFF
--- a/src/routes/kiste/[id]/+page.server.ts
+++ b/src/routes/kiste/[id]/+page.server.ts
@@ -35,7 +35,11 @@ export const actions: Actions = {
 	create: async ({ locals, request }) => {
 		const formData = await request.formData();
 
-		formData.set('kiste', kisteInBearbeitung?.id ?? '');
+		const kistenInStore: Kiste[] = get(kistenStore);
+		const kiste: Kiste | undefined = kistenInStore.find(
+			(kisteStore) => kisteStore.name === formData.get('kiste')
+		);
+		formData.set('kiste', kiste?.id ?? '');
 
 		const bild: File = formData.get('bild') as File;
 

--- a/src/routes/kiste/[id]/+page.svelte
+++ b/src/routes/kiste/[id]/+page.svelte
@@ -86,7 +86,14 @@
 				disabled={loading}
 				type="number"
 			/>
-			<Input id="kiste" required={true} disabled={true} value={data.kiste.name} hidden />
+			<Select
+				id="kiste"
+				label="Kiste"
+				options={data.kisten}
+				required={true}
+				disabled={loading}
+				value={data.kiste.name}
+			/>
 			<Input
 				label="Bild"
 				id="bild"


### PR DESCRIPTION
- the modal dialog for creating a new item (Gegenstand) on the detail route of a box (Kiste) now has the usual select box for a box
- said select box is preset to the box of the detail route (and is, on each data submit, reset to that value)