### PR TITLE
fix(edit-mode): status of edit mode now read from store

### DIFF
--- a/src/lib/components/MobileMenu.svelte
+++ b/src/lib/components/MobileMenu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { editMode } from '$lib/storeClient';
 	import type { MenuSegment } from '$lib/types/menuSegment';
 	import { MenuIcon } from 'svelte-feather-icons';
 
@@ -31,11 +32,7 @@
 									<div class="form-control">
 										<label class={'label cursor-pointer'}>
 											<span class="label-text pr-2">{menuLink.label}</span>
-											<input
-												type="checkbox"
-												class="toggle toggle-sm md:toggle-md toggle-warning"
-												on:click={menuLink.onClick}
-											/>
+											<input type="Input" class={menuLink.cssClass} on:click={menuLink.onClick} />
 										</label>
 									</div>
 								</li>
@@ -57,5 +54,21 @@
 				{/if}
 			{/if}
 		{/each}
+		<li class="menu-title">
+			<span>Modus</span>
+		</li>
+		<li>
+			<div class="form-control">
+				<label class={'label cursor-pointer'}>
+					<span class="label-text pr-2">Edit-Modus</span>
+					<input
+						type="checkbox"
+						class="toggle toggle-sm md:toggle-md toggle-warning"
+						on:click={() => editMode.set(!$editMode)}
+						checked={$editMode}
+					/>
+				</label>
+			</div>
+		</li>
 	</ul>
 </div>

--- a/src/lib/types/linkElement.ts
+++ b/src/lib/types/linkElement.ts
@@ -4,4 +4,5 @@ export interface LinkElement {
 	hidden?: boolean;
 	type?: 'Link' | 'Button' | 'Input';
 	onClick?: () => void;
+	cssClass?: string;
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,10 +18,6 @@
 	$: innerWidth = 0;
 	$: innerHeight = 0;
 
-	const toggleEditMode = () => {
-		editMode.set(!$editMode);
-	};
-
 	let mobileMenuData: MenuSegment[] = [
 		{
 			categoryName: 'Inventar',
@@ -43,17 +39,6 @@
 				{ label: 'Security', href: '/my/settings/security', hidden: isNullOrUndefined(data.user) },
 				{ label: 'Login', href: '/login', hidden: isNotNullOrUndefined(data.user) },
 				{ label: 'Logout', href: '/logout', hidden: isNullOrUndefined(data.user), type: 'Button' }
-			]
-		},
-		{
-			categoryName: 'Modus',
-			entries: [
-				{
-					label: 'Edit-Modus',
-					hidden: isNullOrUndefined(data.user),
-					type: 'Input',
-					onClick: toggleEditMode
-				}
 			]
 		}
 	];
@@ -78,7 +63,8 @@
 									<input
 										type="checkbox"
 										class="toggle toggle-sm md:toggle-md toggle-warning"
-										on:click={toggleEditMode}
+										on:click={() => editMode.set(!$editMode)}
+										checked={$editMode}
 									/>
 								</label>
 							</div>


### PR DESCRIPTION
- added a fxied entry to the mobile menu for the edit mode button instead of passing it in like the other menu entries
- both the edit mode button on mobile as well as desktop have their 'checked' attribute set based on the editMode store value
- the css styles can now be passed in with a link element to the mobile menue